### PR TITLE
Problem with repeats in entertainer.krn

### DIFF
--- a/kern/entertainer.krn
+++ b/kern/entertainer.krn
@@ -561,7 +561,6 @@
 8r	8r	.
 =72	=72	=72
 *k[]	*k[]	*k[]
-*>E	*>E	*>E
 8fL c A F	8ccL	p
 8fJ c A F	16aL	.
 .	[16ccJJ	.
@@ -590,6 +589,7 @@
 8C CC	8ccc gg ee cc	.
 8r	8r	.
 =76!|:	=76!|:	=76!|:
+*>E	*>E	*>E
 8FFL	8fL d	p
 8AJ F	16eL c#	.
 .	[16fJJ [d	.


### PR DESCRIPTION
I think there's a problem with the labeling of sections.  There is a 4-bar phrase (bars 72-75, inclusive) that is encoded as being the beginning of section E (which is the last strain of the piece), which is not correct --- it should be encoded as the last part of section D2 instead.  I think this is clear from the sheet music---there is a start repeat section indicated at measure 76, not 72, so section E should start at 76, not 72.  This problem manifests when repeats are automatically unrolled (which the kernscores website has the ability to do), and what happens is measures 72-75 become part of the repeated section E, when they really shouldn't.

Anyway, I think this change fixes the problem by moving `*>E	*>E	*>E` from bar 72 to 76.